### PR TITLE
Update to index.js to 'require' underscore.string

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -10,7 +10,8 @@ var fs        = require('fs')
   , genUtils  = require('../util.js')
   , yeoman    = require('yeoman-generator')
   , chalk     = require('chalk')
-  , wiredep   = require('wiredep');
+  , wiredep   = require('wiredep')
+  , _         = require('underscore.string');
 
 
 /**


### PR DESCRIPTION
An issue was arising for me with "Cannot read property 'camelize' of undefined occuring at app/index.js:27.

_ is seen as deprecated by node, and requiring underscore.string solves.

Tested locally and it works for me.
